### PR TITLE
Breadcrumb polymorphic props

### DIFF
--- a/lib/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/lib/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import cn from 'classnames';
 
-import { cssProps } from '../../utils/helpers';
+import { cssProps, PolymorphicProps } from '../../utils/helpers';
 import styles from './styles.module.scss';
 
-export type Breadcrumb = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-  label: React.ReactNode;
-};
+export type Breadcrumb<T extends React.ElementType = 'a'> = PolymorphicProps<
+  T,
+  {
+    as?: T;
+    label: React.ReactNode;
+  }
+>;
 
-export type BreadcrumbsProps = React.HTMLAttributes<HTMLOListElement> & {
+export type BreadcrumbsProps = React.OlHTMLAttributes<HTMLOListElement> & {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-  items: Breadcrumb[];
+  items: Breadcrumb<React.ElementType>[];
   separator?: React.ReactNode;
   margin?: React.CSSProperties['margin'];
 };
@@ -30,9 +34,9 @@ export const Breadcrumbs = ({
     className={cn(styles.breadcrumbs, className)}
     style={{ ...style, ...cssProps({ size, margin }) }}
   >
-    {items.map(({ label, ...item }, index) => {
+    {items.map(({ label, as, ...item }, index) => {
       const isLast = index === items.length - 1;
-      const Element = item.href ? 'a' : 'span';
+      const Element = as ?? (item.href ? 'a' : 'span');
 
       return (
         <li key={index}>

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "^3.5.3",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-router-dom": "^6.26.2",
     "sass": "^1.86.0",
     "stylelint": "^16.16.0",
     "typescript": "~5.7.2",

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,9 +1,10 @@
-import { Breadcrumbs, Button, ButtonProps, Heading, Icon, Menu, MenuItem } from '@lib';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Breadcrumb, Breadcrumbs, Button, ButtonProps, Heading, Icon, Menu, MenuItem } from '@lib';
 
-const items = [
+const items: (Breadcrumb | Breadcrumb<typeof Link>)[] = [
   { label: 'Home', href: '/' },
-  { label: 'Men’s Shoes', href: '/shoes' },
+  { label: 'Men’s Shoes', as: Link, to: '/shoes' },
   { label: 'Skateboarding', href: '/shoes/skateboarding' },
   { label: 'Nike SB Dunk Low Pro' },
 ];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import App from './App.tsx';
 
@@ -9,8 +10,15 @@ if (import.meta.env.VITE_DIST) {
 
 import './global.scss';
 
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+  },
+]);
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,6 +671,11 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.0.tgz#8dff61038cb5884789d8b323d9869e5363b976f7"
   integrity sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==
 
+"@remix-run/router@1.23.0":
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
+  integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
+
 "@rollup/pluginutils@^5.1.3", "@rollup/pluginutils@^5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.4.tgz#bb94f1f9eaaac944da237767cdfee6c5b2262d4a"
@@ -2584,6 +2589,21 @@ react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+
+react-router-dom@^6.26.2:
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.0.tgz#a64774104508bff56b1affc2796daa3f7e76b7df"
+  integrity sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==
+  dependencies:
+    "@remix-run/router" "1.23.0"
+    react-router "6.30.0"
+
+react-router@6.30.0:
+  version "6.30.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.0.tgz#9789d775e63bc0df60f39ced77c8c41f1e01ff90"
+  integrity sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==
+  dependencies:
+    "@remix-run/router" "1.23.0"
 
 react-textarea-autosize@^8.5.8:
   version "8.5.9"


### PR DESCRIPTION
Adds a new optional `as` prop for the `Breadcrumb` item.

```tsx
import { Link } from 'react-router-dom';

const items: (Breadcrumb | Breadcrumb<typeof Link>)[] = [
  { label: 'Home', href: '/' },
  { label: 'Men’s Shoes', as: Link, to: '/shoes' },
  { label: 'Nike SB Dunk Low Pro' },
];

<Breadcrumbs items={items} />
```